### PR TITLE
Add maternal egg generation

### DIFF
--- a/refactor/config_data/config.json
+++ b/refactor/config_data/config.json
@@ -126,5 +126,9 @@
         "temperatures": [8.4,7.8,7.7,8.6,9.8,11.65,13.4,13.9,13.9,13.2,12.15,10.2]
       }
     }
+  },
+  "genetic_mechanism": {
+    "description": "The breeding strategy. Can be 'maternal', 'quantitative' or 'discrete'",
+    "value": "discrete"
   }
 }

--- a/refactor/src/Cage.py
+++ b/refactor/src/Cage.py
@@ -624,7 +624,7 @@ class Cage:
                 eggs_generated[tuple(sorted(tuple({sire[1], dam[1]})))] = number_eggs / 4
 
             return eggs_generated
-        else:
+        elif breeding_mathod == 'additive':
             # additive genes, assume genetic state for an individual looks like a number between 0 and 1.
             # because we're only dealing with the heritable part here don't need to do any of the comparison
             # to population mean or impact of heritability, etc - that would appear in the code dealing with treatment
@@ -634,6 +634,12 @@ class Cage:
             mid_parent = np.round((sire + dam)/2, 1)
             eggs_generated[mid_parent] = number_eggs
 
+            return eggs_generated
+        else:
+            # maternal-only inheritance - all eggs have mother's genotype
+            eggs_generated = {}
+            eggs_generated[dam] = number_eggs
+            
             return eggs_generated
 
     @staticmethod

--- a/refactor/src/Cage.py
+++ b/refactor/src/Cage.py
@@ -598,7 +598,7 @@ class Cage:
         TODO: doesn't do anything sensible re: integer/real numbers of offspring
         :param sire the genomics of the sires
         :param dam the genomics of the dams
-        :param breeding_method the breeding strategy. Can be either "additive" or "discrete"
+        :param breeding_method the breeding strategy. Can be "maternal" "quantitative" or "discrete"
         :param num_matings the number of matings
         :returns a distribution on the number of generated eggs according to the distribution
         """
@@ -624,7 +624,7 @@ class Cage:
                 eggs_generated[tuple(sorted(tuple({sire[1], dam[1]})))] = number_eggs / 4
 
             return eggs_generated
-        elif breeding_mathod == 'additive':
+        elif breeding_method == 'quantitative':
             # additive genes, assume genetic state for an individual looks like a number between 0 and 1.
             # because we're only dealing with the heritable part here don't need to do any of the comparison
             # to population mean or impact of heritability, etc - that would appear in the code dealing with treatment

--- a/refactor/src/Config.py
+++ b/refactor/src/Config.py
@@ -111,6 +111,7 @@ class RuntimeConfig:
         self.reproduction_age_dependence = data["reproduction_age_dependence"]["value"]
         self.reproduction_density_dependence = data["reproduction_density_dependence"]["value"]
         self.dam_unavailability = data["dam_unavailability"]["value"]
+        self.genetic_mechanism = data["genetic_mechanism"]["value"]
 
         # Farm data
         self.farm_data = data["farm_data"]["value"]

--- a/refactor/tests/test_Cage.py
+++ b/refactor/tests/test_Cage.py
@@ -275,7 +275,17 @@ class TestCage:
         delta_avail_dams, delta_eggs = first_cage.do_mating_events()
         assert not bool(delta_avail_dams)
         assert not bool(delta_eggs)
-
+    
+    def test_generate_eggs_maternal(self, first_cage):
+        sire = 'z'
+        dam = 'Z'
+        num_matings = 10
+        target_eggs = {dam: 2550}
+        eggs = first_cage.generate_eggs(sire, dam, 'maternal', num_matings)
+        for key in eggs:
+            assert key == dam
+            assert eggs[key] == target_eggs[key]
+    
     def test_generate_eggs_quantitative(self, first_cage):
         sire = 0.7
         dam = 0.0

--- a/refactor/tests/test_Cage.py
+++ b/refactor/tests/test_Cage.py
@@ -254,12 +254,12 @@ class TestCage:
             assert population >= 0
 
     def test_invalid_update_raises(self, first_cage):
-        first_cage.lice_population.geno_by_lifestage['L5m'] = {('A',): 5, ('a',): 5, ('A', 'a'): 5}
+        first_cage.lice_population.geno_by_lifestage["L5m"] = {('A',): 5, ('a',): 5, ('A', 'a'): 5}
         with pytest.raises(AssertionError):
             first_cage.lice_population.available_dams = {('A',): 10}
 
     def test_do_mating_events(self, first_cage):
-        first_cage.lice_population.geno_by_lifestage['L5f'] = {('A',): 15, ('a',): 15, ('A', 'a'): 15}
+        first_cage.lice_population.geno_by_lifestage["L5f"] = {('A',): 15, ('a',): 15, ('A', 'a'): 15}
         first_cage.lice_population.available_dams = {('A',): 15, ('a',): 15}
 
         target_eggs = {('a',): 3024.5, ('A',): 2320.5, tuple(sorted(('a', 'A'))): 3773.0}
@@ -270,28 +270,30 @@ class TestCage:
         assert delta_avail_dams == target_delta_dams
 
     def test_no_available_sires_do_mating_events(self, first_cage):
-        first_cage.lice_population.geno_by_lifestage['L5m'] = {('A',): 0, ('a',): 0, ('A', 'a'): 0}
+        first_cage.lice_population.geno_by_lifestage["L5m"] = {('A',): 0, ('a',): 0, ('A', 'a'): 0}
 
         delta_avail_dams, delta_eggs = first_cage.do_mating_events()
         assert not bool(delta_avail_dams)
         assert not bool(delta_eggs)
     
     def test_generate_eggs_maternal(self, first_cage):
+        first_cage.genetic_mechanism = "maternal"
         sire = 'z'
         dam = 'Z'
         num_matings = 10
         target_eggs = {dam: 2550}
-        eggs = first_cage.generate_eggs(sire, dam, 'maternal', num_matings)
+        eggs = first_cage.generate_eggs(sire, dam, num_matings)
         for key in eggs:
             assert key == dam
             assert eggs[key] == target_eggs[key]
     
     def test_generate_eggs_quantitative(self, first_cage):
+        first_cage.genetic_mechanism = "quantitative"
         sire = 0.7
         dam = 0.0
         num_matings = 10
         target_eggs = {0.4: 2550}
-        eggs = first_cage.generate_eggs(sire, dam, 'quantitative', num_matings)
+        eggs = first_cage.generate_eggs(sire, dam, num_matings)
         for key in eggs:
             assert eggs[key] == target_eggs[key]
 
@@ -299,44 +301,53 @@ class TestCage:
         dam = 0.2
         num_matings = 10
         target_eggs = {0.2: 2401}
-        eggs = first_cage.generate_eggs(sire, dam, 'quantitative', num_matings)
+        eggs = first_cage.generate_eggs(sire, dam, num_matings)
         for key in eggs:
             assert eggs[key] == target_eggs[key]
 
     def test_generate_eggs_discrete(self, first_cage):
-        breeding_method = 'discrete'
+        first_cage.genetic_mechanism = "discrete"
 
         sire = ('A',)
         dam = ('A',)
         hom_dom_target = {('A',): 1533}
 
         num_matings = 6
-        egg_result_hom_dom = first_cage.generate_eggs(sire, dam, breeding_method, num_matings)
+        egg_result_hom_dom = first_cage.generate_eggs(sire, dam, num_matings)
         assert egg_result_hom_dom == hom_dom_target
 
         sire = ('a',)
         dam = ('a',)
         hom_rec_target = {('a',): 1418}
-        egg_result_hom_rec = first_cage.generate_eggs(sire, dam, breeding_method, num_matings)
+        egg_result_hom_rec = first_cage.generate_eggs(sire, dam, num_matings)
         assert egg_result_hom_rec == hom_rec_target
 
         sire = tuple(sorted(('a', 'A')))
         dam = ('a',)
         het_target_sire = {('a',): 778.5, tuple(sorted(('a', 'A'))): 778.5}
-        egg_result_het_sire = first_cage.generate_eggs(sire, dam, breeding_method, num_matings)
+        egg_result_het_sire = first_cage.generate_eggs(sire, dam, num_matings)
         assert egg_result_het_sire == het_target_sire
 
         dam = tuple(sorted(('a', 'A')))
         sire = ('a',)
         het_target_dam = {('a',): 765.0, tuple(sorted(('a', 'A'))): 765.0}
-        egg_result_het_dam = first_cage.generate_eggs(sire, dam, breeding_method, num_matings)
+        egg_result_het_dam = first_cage.generate_eggs(sire, dam, num_matings)
         assert egg_result_het_dam == het_target_dam
 
         dam = tuple(sorted(('a', 'A')))
         sire = tuple(sorted(('a', 'A')))
         het_target = {('A', 'a'): 761.5, ('A',): 380.75, ('a',): 380.75}
-        egg_result_het = first_cage.generate_eggs(sire, dam, breeding_method, num_matings)
+        egg_result_het = first_cage.generate_eggs(sire, dam, num_matings)
         assert egg_result_het == het_target
+
+    def test_generate_eggs_bad_mechanism(self, first_cage):
+        sire = ('A',)
+        dam = ('A',)
+        num_matings = 6
+        first_cage.genetic_mechanism = "dummy"
+
+        with pytest.raises(Exception):
+            first_cage.generate_eggs(sire, dam, num_matings)
 
     def test_not_enough_dams_select_dams(self, first_cage):
 
@@ -385,7 +396,7 @@ class TestCage:
         assert all(age_distrib > 0)
 
     def test_get_num_eggs_no_females(self, first_cage):
-        first_cage.lice_population['L5f'] = 0
+        first_cage.lice_population["L5f"] = 0
         assert first_cage.get_num_eggs(0) == 0
 
     def test_get_num_eggs(self, first_cage):


### PR DESCRIPTION
This has maternal genotype egg generation and a test added for that, but no option for use of this mechanism yet in do_mating_events (discrete is hard-coded).  OK to merge this and then add the option of what type of genetic mechanism to use separately? 