### PR TITLE
Farm and cage start dates functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ lice_counts*.txt
 htmlcov/
 coverage.xml
 
+# Typechecking
+/.pytype
+
 # Original .gitignore
 Figures/
 reading/

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ To test, also from ```refactor``` directory, run:
 ### Original
 To run the original code, enter ```original``` directory and run:
 
-```` python model/slm.py param_module_name output_folder simulation_name```
+```python model/slm.py param_module_name output_folder simulation_name```
 
 For example:
 
-```` python model/slm.py dummy_vars /out/ 0```
+```python model/slm.py dummy_vars /out/ 0```
 
 *Note that at the moment dummy_vars is a copy of Fyne_vars and code execution takes a while.*
 

--- a/refactor/config_data/config.json
+++ b/refactor/config_data/config.json
@@ -126,5 +126,9 @@
         "temperatures": [8.4,7.8,7.7,8.6,9.8,11.65,13.4,13.9,13.9,13.2,12.15,10.2]
       }
     }
+  },
+  "genetic_ratios": {
+    "description": "Genetic ratios of lice population",
+    "value": {"A": 0.25, "a": 0.25, "A,a": 0.5}
   }
 }

--- a/refactor/src/Cage.py
+++ b/refactor/src/Cage.py
@@ -640,8 +640,11 @@ class Cage:
         return delta_dams_selected
 
     def choose_from_distrib(self, distrib: GenoDistrib) -> Alleles:
-        distrib_values = np.array(list(distrib.values()), dtype=object)
-        return tuple(self.cfg.rng.choice(list(distrib.keys()), p=distrib_values / np.sum(distrib_values)))
+        distrib_values = np.array(list(distrib.values()))
+        keys = list(distrib.keys())
+        choice_ix = self.cfg.rng.choice(range(len(keys)), p=distrib_values / np.sum(distrib_values))
+
+        return tuple(keys[choice_ix])
 
     def get_num_eggs(self, mated_females) -> int:
         """

--- a/refactor/src/Cage.py
+++ b/refactor/src/Cage.py
@@ -178,6 +178,10 @@ class Cage:
         date
         """
 
+        if cur_date < self.start_date:
+            self.logger.debug("\tSkipping farm {} / cage {} (not started yet)".format(self.farm_id, self.id))
+            return {}
+
         self.logger.debug(f"\tUpdating farm {self.farm_id} / cage {self.id}")
         self.logger.debug(f"\t\tinitial lice population = {self.lice_population}")
         self.logger.debug(f"\t\tinitial fish population = {self.num_fish}")

--- a/refactor/src/Cage.py
+++ b/refactor/src/Cage.py
@@ -231,7 +231,6 @@ class Cage:
             num_infection_events,
             lice_from_reservoir,
             avail_dams_batch,
-            new_egg_batch,
             new_offspring_distrib,
             returned_dams,
             hatched_arrivals_dist
@@ -877,7 +876,6 @@ class Cage:
             new_infections: int,
             lice_from_reservoir: dict,
             delta_dams_batch: DamAvailabilityBatch,
-            new_egg_batch: EggBatch,
             new_offspring_distrib: dict,
             returned_dams: dict,
             hatched_arrivals_dist: dict
@@ -894,7 +892,6 @@ class Cage:
         :param new_infections the number of new infections (i.e. progressions from L2 to L3)
         :param lice_from_reservoir the number of lice taken from the reservoir
         :param delta_dams_batch the genotypes of now-unavailable females in batch events
-        :param new_egg_batch the expected hatching time of those egg with a related genomics
         :param new_offspring_distrib the new offspring obtained from hatching and migrations
         :param returned_dams the genotypes of returned dams
         :param hatched_arrivals_dist: new offspring obtained from arrivals
@@ -925,13 +922,10 @@ class Cage:
         # in absence of wildlife genotype, simply upgrade accordingly
         # TODO: switch to generic genotype distribs?
         self.lice_population["L1"] += lice_from_reservoir["L1"]
-
-        delta_eggs = new_egg_batch.geno_distrib
+        
         delta_avail_dams = delta_dams_batch.geno_distrib
         self.update_distrib_discrete_subtract(delta_avail_dams, self.lice_population.available_dams)
         self.update_distrib_discrete_add(returned_dams, self.lice_population.available_dams)
-        self.update_distrib_discrete_add(delta_eggs, self.egg_genotypes)
-        self.update_distrib_discrete_subtract(delta_eggs, new_offspring_distrib)
 
         self.busy_dams.put(delta_dams_batch)
 

--- a/refactor/src/Cage.py
+++ b/refactor/src/Cage.py
@@ -12,12 +12,13 @@ import numpy as np
 from scipy import stats
 
 from src.Config import Config
-from src.LicePopulation import (Alleles, GenoDistrib, GrossLiceDistrib,
-                                LicePopulation)
-from src.QueueBatches import DamAvailabilityBatch, EggBatch, TravellingEggBatch
 
 if TYPE_CHECKING:
     from src.Farm import Farm
+
+from src.LicePopulation import (Alleles, GenoDistrib, GrossLiceDistrib,
+                                LicePopulation)
+from src.QueueBatches import DamAvailabilityBatch, EggBatch, TravellingEggBatch
 
 
 class Cage:
@@ -184,14 +185,15 @@ class Cage:
 
         self.logger.debug("\t\tfinal lice population= {}".format(self.lice_population))
 
-        if cur_date >= self.start_date:
+        egg_distrib = {}    # type: GenoDistrib
+        hatch_date = None   # type: Optional[dt.datetime]
+        if cur_date >= self.start_date and new_egg_batch:
             self.logger.debug("\t\tfinal fish population = {}".format(self.num_fish))
             egg_distrib = new_egg_batch.geno_distrib
             hatch_date = new_egg_batch.hatch_date
             self.logger.debug("\t\tlice offspring = {}".format(sum(egg_distrib.values())))
-            return egg_distrib, hatch_date
-        else:
-            return {}, None
+
+        return egg_distrib, hatch_date
 
     def get_lice_treatment_mortality_rate(self, cur_date):
         """

--- a/refactor/src/Config.py
+++ b/refactor/src/Config.py
@@ -112,6 +112,9 @@ class RuntimeConfig:
         self.reproduction_density_dependence = data["reproduction_density_dependence"]["value"]
         self.dam_unavailability = data["dam_unavailability"]["value"]
 
+        # TODO: take into account processing of non-discrete keys
+        self.genetic_ratios = {tuple(sorted(key.split(","))): val for key, val in data["genetic_ratios"]["value"].items()}
+
         # Farm data
         self.farm_data = data["farm_data"]["value"]
 

--- a/refactor/src/Farm.py
+++ b/refactor/src/Farm.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import numpy as np
 
+# TODO: deal with the pytype dependency error
 from src.Cage import Cage  # pytype: disable=pyi-error
 from src.Config import Config
 from src.JSONEncoders import CustomFarmEncoder

--- a/refactor/src/Farm.py
+++ b/refactor/src/Farm.py
@@ -83,6 +83,10 @@ class Farm:
         :return: Dictionary of genotype distributions based on hatch date
         """
 
+        if cur_date < self.start_date:
+            self.logger.debug("Skipping farm {} (not started yet)".format(self.name))
+            return {}
+
         self.logger.debug("Updating farm {}".format(self.name))
 
         # get number of lice from reservoir to be put in each cage

--- a/refactor/src/Farm.py
+++ b/refactor/src/Farm.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import numpy as np
 
-from src.Cage import Cage
+from src.Cage import Cage  # pytype: disable=pyi-error
 from src.Config import Config
 from src.JSONEncoders import CustomFarmEncoder
 

--- a/refactor/src/LicePopulation.py
+++ b/refactor/src/LicePopulation.py
@@ -1,0 +1,77 @@
+import copy
+from collections.abc import MutableMapping
+
+import numpy as np
+from src.Config import Config
+
+
+# See https://stackoverflow.com/a/7760938
+class LicePopulation(dict, MutableMapping):
+    """
+    Wrapper to keep the global population and genotype information updated
+    This is definitely a convoluted way to do this, but I wanted to memoise as much as possible.
+    """
+    def __init__(self, initial_population: dict, geno_data: dict, cfg: Config):
+        super().__init__()
+        self.geno_by_lifestage = GenotypePopulation(self, geno_data)
+        self._available_dams = copy.deepcopy(self.geno_by_lifestage["L5f"])
+        self.genetic_ratios = cfg.genetic_ratios
+        self.logger = cfg.logger
+        for k, v in initial_population.items():
+            super().__setitem__(k, v)
+
+    def __setitem__(self, stage, value):
+        # If one attempts to make gross modifications to the population these will be repartitioned according to the
+        # current genotype information.
+        if sum(self.geno_by_lifestage[stage].values()) == 0:
+            self.logger.warning(f"Trying to initialise population {stage} with null genotype distribution. Using default genotype information.")
+            self.geno_by_lifestage.raw_update_value(stage, self.multiply_distrib(self.genetic_ratios, value))
+        else:
+            self.geno_by_lifestage.raw_update_value(stage, self.multiply_distrib(self.geno_by_lifestage[stage], value))
+        if stage == "L5f":
+            self._available_dams = self.multiply_distrib(self._available_dams, value)
+        super().__setitem__(stage, value)
+
+    def raw_update_value(self, stage, value):
+        super().__setitem__(stage, value)
+
+    @property
+    def available_dams(self):
+        return self._available_dams
+
+    @available_dams.setter
+    def available_dams(self, new_value: dict):
+        for geno in new_value:
+            assert self.geno_by_lifestage["L5f"][geno] >= new_value[geno], f"current population geno {geno}:{self.geno_by_lifestage['L5f'][geno]} is smaller than new value geno {new_value[geno]}"
+
+        self._available_dams = new_value
+
+    @staticmethod
+    def multiply_distrib(distrib: dict, population: int):
+        keys = distrib.keys()
+        values = list(distrib.values())
+        np_values = np.array(values)
+        if np.isclose(np.sum(np_values), 0.0) or population == 0:
+            return dict(zip(keys, map(int, np.zeros_like(np_values))))
+        np_values = np_values * population / np.sum(np_values)
+        np_values = np_values.round().astype('int32')
+        # correct casting errors
+        np_values[-1] += population - np.sum(np_values)
+
+        return dict(zip(keys, map(int, np_values)))
+
+
+class GenotypePopulation(dict, MutableMapping):
+    def __init__(self, gross_lice_population: LicePopulation, geno_data: dict):
+        super().__init__()
+        self._lice_population = gross_lice_population
+        for k, v in geno_data.items():
+            super().__setitem__(k, v)
+
+    def __setitem__(self, stage: str, value: dict):
+        # update the value and the gross population accordingly
+        super().__setitem__(stage, value)
+        self._lice_population.raw_update_value(stage, sum(value.values()))
+
+    def raw_update_value(self, stage, value):
+        super().__setitem__(stage, value)

--- a/refactor/src/LicePopulation.py
+++ b/refactor/src/LicePopulation.py
@@ -70,6 +70,29 @@ class LicePopulation(dict, MutableMapping[LifeStage, int]):
 
         return dict(zip(keys, map(int, np_values)))
 
+    @staticmethod
+    def update_distrib_discrete_add(distrib_delta, distrib):
+        """
+        I've assumed that both distrib and delta are dictionaries
+        and are *not* normalised (that is, they are effectively counts)
+        I've also assumed that we never want a count below zero
+        Code is naive - interpret as algorithm spec
+        combine these two functions with a negation of a dict?
+        """
+
+        for geno in distrib_delta:
+            if geno not in distrib:
+                distrib[geno] = 0
+            distrib[geno] += distrib_delta[geno]
+
+    @staticmethod
+    def update_distrib_discrete_subtract(distrib_delta, distrib):
+        for geno in distrib:
+            if geno in distrib_delta:
+                distrib[geno] -= distrib_delta[geno]
+            if distrib[geno] < 0:
+                distrib[geno] = 0
+
 
 class GenotypePopulation(dict, MutableMapping[LifeStage, GenoDistrib]):
     def __init__(self, gross_lice_population: LicePopulation, geno_data: GenoLifeStageDistrib):

--- a/refactor/src/QueueBatches.py
+++ b/refactor/src/QueueBatches.py
@@ -1,0 +1,21 @@
+import datetime as dt
+from dataclasses import dataclass, field
+
+
+@dataclass(order=True)
+class EggBatch:
+    hatch_date: dt.datetime
+    geno_distrib: dict = field(compare=False)
+
+
+@dataclass(order=True)
+class TravellingEggBatch:
+    arrival_date: dt.datetime
+    hatch_date: dt.datetime = field(compare=False)
+    geno_distrib: dict = field(compare=False)
+
+
+@dataclass(order=True)
+class DamAvailabilityBatch:
+    availability_date: dt.datetime # expected return time
+    geno_distrib: dict = field(compare=False)

--- a/refactor/tests/conftest.py
+++ b/refactor/tests/conftest.py
@@ -3,9 +3,15 @@ import numpy as np
 import pytest
 import datetime
 
-from src.Config import Config, to_dt
+from src.Config import Config
 from src.Farm import Farm
-from src.Cage import EggBatch, DamAvailabilityBatch
+from src.QueueBatches import EggBatch, DamAvailabilityBatch
+from src.LicePopulation import LicePopulation
+
+
+@pytest.fixture
+def initial_lice_population():
+    return {"L1": 150, "L2": 0, "L3": 30, "L4": 30, "L5f": 10, "L5m": 10}
 
 
 @pytest.fixture
@@ -16,15 +22,17 @@ def farm_config():
 
 
 @pytest.fixture
-def farm(farm_config):
-    return Farm(0, farm_config)
+def farm(farm_config, initial_lice_population):
+    return Farm(0, farm_config, initial_lice_population)
+
 
 @pytest.fixture
-def farm_two(farm_config):
+def farm_two(farm_config, initial_lice_population):
     # use config of farm 1 but change the name
-    farm = Farm(0, farm_config)
+    farm = Farm(0, farm_config, initial_lice_population)
     farm.name = 1
     return farm
+
 
 @pytest.fixture
 def first_cage(farm):
@@ -43,6 +51,7 @@ def null_offspring_distrib():
         ('a',): 0,
         ('A', 'a'): 0,
     }
+
 
 @pytest.fixture
 def sample_offspring_distrib():
@@ -71,3 +80,12 @@ def null_dams_batch(null_offspring_distrib, farm):
 @pytest.fixture
 def sample_eggs_by_hatch_date(sample_offspring_distrib, farm):
     return {farm.start_date: null_offspring_distrib}
+
+
+@pytest.fixture
+def planctonic_only_population(first_cage):
+    lice_pop = {"L1": 100, "L2": 200, "L3": 0, "L4": 0, "L5f": 0, "L5m": 0}
+    geno = {stage: {("a",): 0, ("A", "a"): 0, ("A",): 0} for stage in lice_pop.keys()}
+    geno["L1"][("a",)] = 100
+    geno["L2"][("a",)] = 200
+    return LicePopulation(lice_pop, geno, {}, first_cage.logger)

--- a/refactor/tests/test_Cage.py
+++ b/refactor/tests/test_Cage.py
@@ -211,7 +211,7 @@ class TestCage:
         first_cage.lice_population["L5f"] = 1000
         assert 900 <= first_cage.get_num_matings() <= 1000
 
-    def test_update_deltas_no_negative_raise(self, first_cage, null_egg_batch, null_offspring_distrib, null_dams_batch):
+    def test_update_deltas_no_negative_raise(self, first_cage, null_offspring_distrib, null_dams_batch):
         first_cage.lice_population["L3"] = 0
         first_cage.lice_population["L4"] = 0
         first_cage.lice_population["L5m"] = 0
@@ -244,7 +244,6 @@ class TestCage:
             new_infections,
             reservoir_lice,
             null_dams_batch,
-            null_egg_batch,
             null_offspring_distrib,
             null_returned_dams,
             null_hatched_arrivals

--- a/refactor/tests/test_Cage.py
+++ b/refactor/tests/test_Cage.py
@@ -597,3 +597,9 @@ class TestCage:
 
     def test_get_reservoir_lice_no_pressure(self, first_cage):
         assert first_cage.get_reservoir_lice(0) == {"L1": 0, "L2": 0}
+
+    def test_update_step_before_start(self, first_cage):
+        cur_date = first_cage.start_date - dt.timedelta(1)
+        offspring = first_cage.update(cur_date, 1, 0)
+
+        assert offspring == {}

--- a/refactor/tests/test_Cage.py
+++ b/refactor/tests/test_Cage.py
@@ -2,14 +2,13 @@ import copy
 import datetime
 import datetime as dt
 import itertools
+import json
 
 import numpy as np
 import pytest
-
-import json
-
+from src.Cage import Cage
 from src.Config import to_dt
-from src.QueueBatches import EggBatch, DamAvailabilityBatch, TravellingEggBatch
+from src.QueueBatches import DamAvailabilityBatch, EggBatch, TravellingEggBatch
 
 
 class TestCage:
@@ -83,7 +82,7 @@ class TestCage:
         min_development_stage = 4
         mean_development_stage = 8
 
-        for i in range(100):
+        for _ in range(100):
             stage_ages = first_cage.get_evolution_ages(
                 test_num_lice,
                 minimum_age=min_development_stage,
@@ -137,7 +136,7 @@ class TestCage:
 
         assert new_l4 == 0
         assert new_females == 0
-        assert new_females == 0
+        assert new_males == 0
 
     def test_get_fish_growth(self, first_cage):
         first_cage.num_fish *= 300
@@ -158,6 +157,8 @@ class TestCage:
             first_cage.lice_population[k] = 0
 
         _, lice_death = first_cage.get_fish_growth(1, 1)
+
+        assert lice_death == 0
 
     def test_get_infection_rates(self, first_cage):
         first_cage.lice_population["L2"] = 100
@@ -283,7 +284,7 @@ class TestCage:
         delta_avail_dams, delta_eggs = first_cage.do_mating_events()
         assert not bool(delta_avail_dams)
         assert not bool(delta_eggs)
-    
+
     def test_generate_eggs_maternal(self, first_cage):
         first_cage.genetic_mechanism = "maternal"
         sire = 'z'
@@ -294,7 +295,7 @@ class TestCage:
         for key in eggs:
             assert key == dam
             assert eggs[key] == target_eggs[key]
-    
+
     def test_generate_eggs_quantitative(self, first_cage):
         first_cage.genetic_mechanism = "quantitative"
         sire = 0.7
@@ -367,7 +368,7 @@ class TestCage:
         for key in delta_dams:
             assert delta_dams[key] == distrib_dams_available[key]
         for key in delta_dams:
-            assert  distrib_dams_available[key] == delta_dams[key]
+            assert distrib_dams_available[key] == delta_dams[key]
 
     def test_update_step(self, first_cage, cur_day):
         first_cage.update(cur_day, 1, 0)
@@ -422,7 +423,7 @@ class TestCage:
         assert batch1 < batch2
 
     def test_get_egg_batch(self, first_cage, cur_day):
-        busy_dams, new_eggs = first_cage.do_mating_events()
+        _, new_eggs = first_cage.do_mating_events()
         target_egg_distrib = {('A', 'a'): 4644.5, ('A',): 2698.25, ('a',): 1927.25}
 
         new_egg_batch = first_cage.get_egg_batch(cur_day, new_eggs)
@@ -538,7 +539,7 @@ class TestCage:
         assert first_cage.lice_population["L4"] == target_population
 
         # L3 must be unchanged
-        assert first_cage.lice_population.geno_by_lifestage["L3"] == {('A',): 1000, ('a',): 1000, ('A', 'a'): 1000}
+        assert first_cage.lice_population.geno_by_lifestage["L3"] == old_L3
 
     def test_promote_population_offspring(self, first_cage):
         offspring_distrib = {('A',): 500, ('a',): 500, ('A', 'a'): 500}
@@ -642,10 +643,7 @@ class TestCage:
 
         assert offspring == {}
         assert hatch_date is None
-        assert first_cage.lice_population["L3"] == 0
-        assert first_cage.lice_population["L4"] == 0
-        assert first_cage.lice_population["L5f"] == 0
-        assert first_cage.lice_population["L5m"] == 0
+        assert all(first_cage.lice_population[susceptible_stage] == 0 for susceptible_stage in Cage.susceptible_stages)
         assert first_cage.num_fish == 4000
         assert first_cage.num_infected_fish == 0
         assert first_cage.arrival_events.qsize() == 0
@@ -656,10 +654,7 @@ class TestCage:
 
         assert offspring == {}
         assert hatch_date is None
-        assert first_cage.lice_population["L3"] == 0
-        assert first_cage.lice_population["L4"] == 0
-        assert first_cage.lice_population["L5f"] == 0
-        assert first_cage.lice_population["L5m"] == 0
+        assert all(first_cage.lice_population[susceptible_stage] == 0 for susceptible_stage in Cage.susceptible_stages)
         assert first_cage.num_fish == 4000
         assert first_cage.num_infected_fish == 0
         assert first_cage.arrival_events.qsize() == 0
@@ -684,10 +679,7 @@ class TestCage:
 
         assert offspring == {}
         assert hatch_date is None
-        assert first_cage.lice_population["L3"] == 0
-        assert first_cage.lice_population["L4"] == 0
-        assert first_cage.lice_population["L5f"] == 0
-        assert first_cage.lice_population["L5m"] == 0
+        assert all(first_cage.lice_population[susceptible_stage] == 0 for susceptible_stage in Cage.susceptible_stages)
         assert first_cage.num_fish == 4000
         assert first_cage.num_infected_fish == 0
 
@@ -708,10 +700,7 @@ class TestCage:
 
         assert offspring == {}
         assert hatch_date is None
-        assert first_cage.lice_population["L3"] == 0
-        assert first_cage.lice_population["L4"] == 0
-        assert first_cage.lice_population["L5f"] == 0
-        assert first_cage.lice_population["L5m"] == 0
+        assert all(first_cage.lice_population[susceptible_stage] == 0 for susceptible_stage in Cage.susceptible_stages)
         assert first_cage.num_fish == 4000
         assert first_cage.num_infected_fish == 0
 

--- a/refactor/tests/test_Farm.py
+++ b/refactor/tests/test_Farm.py
@@ -159,3 +159,9 @@ class TestFarm:
 
         assert total == 105
         assert by_cage == [70, 35]
+
+    def test_farm_update_before_start(self, farm):
+        cur_date = farm.start_date - dt.timedelta(1)
+        offspring = farm.update(cur_date, 1)
+
+        assert offspring == {}


### PR DESCRIPTION
Closes #72 

- Under the new changes non-operating farms and cages that has not yet reached starting date are updated but only with updates that do not require the fish
- Moved `LicePopulation` and queue batches from `Cage.py` to separate files
- Added wee fix to stop pytest numpy warnings