### PR TITLE
Feature/visualiser more plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To _resume_ a session one can instead pass the `--resume` parameter, e.g.
 We also provide a GUI for debugging and visualisation. Its support is still heavily experimental so please
 use with caution.
 
-You can lauch it via `python -m src.SeaLiceMgmtGUI` and provide your run data (generated via the `--save-rate` option mentioned
+You can launch it via `python -m src.SeaLiceMgmtGUI` and provide your run data (generated via the `--save-rate` option mentioned
 above) from the given menu.
 
 ## Testing

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - pip=21.2.2
   - pyqt==5.12.3
   - pyqtgraph==0.11.0
+  - colorcet=2.0.6
   - pip:
       - pytype==2021.07.19
       - iteround==1.0.2

--- a/refactor/src/Farm.py
+++ b/refactor/src/Farm.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import copy
 import datetime as dt
 import json
-from collections import Counter
+from collections import Counter, defaultdict
 from queue import PriorityQueue
 from typing import Dict, List, Optional, Tuple
 
@@ -104,8 +104,20 @@ class Farm:
 
     @property
     def lice_population(self):
+        """Return the overall lice population in a farm"""
         return dict(sum([Counter(cage.lice_population.as_dict()) for cage in self.cages], Counter()))
 
+    @property
+    def lice_genomics(self):
+        """Return the overall lice population indexed by geno distribution and stage."""
+
+        genomics = defaultdict(lambda: GenericGenoDistrib())
+        for cage in self.cages:
+            for stage, value in cage.lice_population.geno_by_lifestage.as_dict().items():
+                genomics[stage] = genomics[stage] + value
+
+
+        return {k: v.to_json_dict() for k, v in genomics.items()}
     def initialise_temperatures(self, temperatures: Dict[str, LocationTemps]) -> np.ndarray:
         """
         Calculate the mean sea temperature at the northing coordinate of the farm at

--- a/refactor/src/LicePopulation.py
+++ b/refactor/src/LicePopulation.py
@@ -387,3 +387,6 @@ class GenotypePopulation(MutableMapping[LifeStage, GenericGenoDistrib]):
 
     def to_json_dict(self):
         return {k: v.to_json_dict() for k, v in self.items()}
+
+    def as_dict(self):
+        return self._store

--- a/refactor/src/SeaLiceMgmtGUI.py
+++ b/refactor/src/SeaLiceMgmtGUI.py
@@ -1,17 +1,17 @@
 import datetime as dt
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Dict
 
-import pandas as pd
-from colorcet import glasbey_dark
 import numpy as np
+import pandas as pd
 import pyqtgraph as pg
 from PyQt5 import QtGui, QtWidgets
-from PyQt5.QtCore import QThread, pyqtSignal, QObject, QTimer, QSettings, Qt
+from PyQt5.QtCore import QThread, pyqtSignal, QObject, QTimer, QSettings
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QMenu,
-                             QAction, QFileDialog, QMessageBox, QGridLayout, QProgressBar, QSplitter, QCheckBox,
-                             QGroupBox, QVBoxLayout, QComboBox)
+                             QAction, QFileDialog, QMessageBox, QGridLayout, QProgressBar, QCheckBox,
+                             QGroupBox, QVBoxLayout)
+from colorcet import glasbey_dark, glasbey_light
 
 from src.LicePopulation import LicePopulation
 from src.Simulator import Simulator
@@ -40,32 +40,49 @@ class Window(QMainWindow):
         self.wd.setLayout(mainLayout)
 
         mainLayout.addWidget(self.plotPane, 0, 0, 2, 1)
-        mainLayout.addWidget(self.plotButtonGroup, 0, 1)
-        mainLayout.addWidget(self.progressBar, 2, 0, 1, 2)
-
-        #mainLayout.setRowStretch(1, 1)
-        #mainLayout.setRowStretch(2, 1)
+        mainLayout.addWidget(self.plotButtonGroup, 2, 0)
+        mainLayout.addWidget(self.progressBar, 3, 0, 1, 2)
 
         self._createSettings()
         self._createActions()
         self._connectActions()
         self._createMenuBar()
 
+    @property
+    def _getUniqueFarms(self):
+        if self.states:
+            return self.states_as_df.reset_index()["farm_name"].unique()
+        return []
+
+    @property
+    def _colorPalette(self):
+        if self.paperModeAction.isChecked():
+            return glasbey_light
+        return glasbey_dark
+
     def _createPlots(self):
-        ## PLOTS
+        num_farms = len(self._getUniqueFarms)
+
         self.plotPane = pg.GraphicsLayoutWidget(self)
 
-        self.licePopulationPlot = self.plotPane.addPlot(title="Lice Population per stage", row=0, col=0)
+        self.licePopulationPlots = [self.plotPane.addPlot(title=f"Lice Population of farm {i}", row=0, col=i)
+                                    for i in range(num_farms)]
         self.payoffPlot = self.plotPane.addPlot(title="Cumulated payoff", row=1, col=0)
-        self.payoffPlot.setXLink(self.licePopulationPlot)
+        # self.payoffPlot.setXLink(self.licePopulationPlots[0])
 
-        self.licePopulationLegend = None
+        self.licePopulationLegend = []
 
-        # We cannot know the genotypes in advance
-        self.geno_to_curve = {}
-        self.stages_to_curve = {}
+        self.geno_to_curve: Dict[str, Dict[str, pg.PlotItem]] = {}
+        self.stages_to_curve: Dict[str, Dict[str, pg.PlotItem]] = {}
 
-        self.licePopulationPlot.showGrid(x=True, y=True)
+        # add grid, synchronise Y-range
+        # TODO: make this toggleable?
+        for plot in self.licePopulationPlots:
+            plot.showGrid(x=True, y=True)
+        for idx in range(1, len(self.licePopulationPlots)):
+            # TODO is this a good idea?
+            self.licePopulationPlots[idx].setYLink(self.licePopulationPlots[idx - 1])
+
         self.payoffPlot.showGrid(x=True, y=True)
 
     def _createWidgets(self):
@@ -77,12 +94,9 @@ class Window(QMainWindow):
         # Pane on the right
         self.plotButtonGroup = QGroupBox("Plot options", self)
         self.plotButtonGroupLayout = QVBoxLayout()
-        self.farmSelector = QComboBox(self)
-        self.farmSelector.setEnabled(False)
         self.showDetailedGenotypeCheckBox = QCheckBox("S&how detailed genotype information", self)
 
         self.showDetailedGenotypeCheckBox.stateChanged.connect(lambda _: self._updatePlot())
-        self.plotButtonGroupLayout.addWidget(self.farmSelector)
         self.plotButtonGroupLayout.addWidget(self.showDetailedGenotypeCheckBox)
         self.plotButtonGroup.setLayout(self.plotButtonGroupLayout)
 
@@ -107,7 +121,7 @@ class Window(QMainWindow):
         self.states_as_df = Simulator.dump_as_pd(states, times)
 
         # how many unique farms are there?
-        #farms = self.states[0].organisation.farms
+        # farms = self.states[0].organisation.farms
 
         self._updatePlot()
 
@@ -132,57 +146,91 @@ class Window(QMainWindow):
 
     def _cleanPlot(self):
         self.payoffPlot.clear()
-        for curve in self.stages_to_curve.values():
-            curve.clear()
-        for curve in self.geno_to_curve.values():
-            curve.clear()
+        for curves in self.stages_to_curve.values():
+            for curve in curves.values():
+                curve.clear()
+        for curves in self.geno_to_curve.values():
+            for curve in curves.values():
+                curve.clear()
 
         if self.licePopulationLegend:
-            self.licePopulationLegend.clear()
+            for v in self.licePopulationLegend:
+                v.clear()
+            self.licePopulationLegend = []
+
+    def _remountPlot(self):
+        layout: QGridLayout = self.wd.layout()
+        layout.removeWidget(self.plotPane)
+        # I need to know the exact number of farms right now
+        self._createPlots()
+        layout.addWidget(self.plotPane, 0, 0, 2, 1)
+        self._updatePlot()
+
 
     def _updatePlot(self):
         # TODO: not suited for real-time
-        # TODO: only showing one farm here
 
         self._cleanPlot()
         if self.states is None:
             return
 
-        self.licePopulationLegend = self.licePopulationPlot.addLegend()
+        # TODO this is ugly. Wrap this logic inside a widget with a few slots
+        # if the number of farms has changed
+        elif len(self._getUniqueFarms) != len(self.licePopulationPlots):
+            self._remountPlot()
+
+        for plot in self.licePopulationPlots:
+            self.licePopulationLegend.append(plot.addLegend())
+
+        farm_list = self._getUniqueFarms
 
         if self.showDetailedGenotypeCheckBox.isChecked():
             df = self.states_as_df.reset_index()
 
-            first_farm_df = df[df["farm_name"] == "farm_0"]
-            allele_names = ["a", "A", "Aa"] # TODO: extract from column names
-            colours = dict(zip(allele_names, glasbey_dark[:len(allele_names)]))
 
-            allele_data = {allele: first_farm_df[allele].to_numpy() for allele in allele_names}
-            self.geno_to_curve = {allele_name: self.licePopulationPlot.plot(stage_value, name=allele_name, pen=colours[allele_name])
-                                  for allele_name, stage_value in allele_data.items()}
+            allele_names = ["a", "A", "Aa"]  # TODO: extract from column names
+            colours = dict(zip(allele_names, self._colorPalette[:len(allele_names)]))
+
+            for farm_idx, farm_name in enumerate(farm_list):
+                farm_df = df[df["farm_name"] == farm_name]
+
+                allele_data = {allele: farm_df[allele].to_numpy() for allele in allele_names}
+                self.geno_to_curve[farm_name] = {
+                    allele_name: self.licePopulationPlots[farm_idx].plot(stage_value, name=allele_name,
+                                                                         pen=colours[allele_name])
+                    for allele_name, stage_value in allele_data.items()
+                }
         else:
             # TODO: use pandas here
-            population_data = []
+            population_data = {}
             for snapshot in self.states:
-                population_data.append(snapshot.organisation.farms[0].lice_population)
+                farms = snapshot.organisation.farms
+                for farm in farms:
+                    population_data.setdefault(farm.name, []).append(farm.lice_population)
 
-            # render per stage
-            stages = {k: np.array([population.get(k, 0) for population in population_data]) for k in LicePopulation.lice_stages}
+            for farm_idx, farm_name in enumerate(farm_list):
+                # TODO: this is ugly
+                farm_name_as_int = int(farm_name[len("farm_"):])
+                stages = {k: np.array([population.get(k, 0) for population in population_data[farm_name_as_int]]) for k in
+                          LicePopulation.lice_stages}
+                # render per stage
+                colours = dict(zip(LicePopulation.lice_stages, self._colorPalette[:len(stages)]))
 
-            # TODO: use a proper color palette from colorcet or matplotlib
-            colours = dict(zip(LicePopulation.lice_stages, glasbey_dark[:len(stages)]))
-            self.stages_to_curve = {stage: self.licePopulationPlot.plot(stages[stage], name=stage, pen=colours[stage])
-                                    for stage in LicePopulation.lice_stages}
+                self.stages_to_curve[farm_name] = {
+                    stage: self.licePopulationPlots[farm_idx].plot(stages[stage], name=stage, pen=colours[stage])
+                    for stage in LicePopulation.lice_stages}
 
         payoffs = [float(state.payoff) for state in self.states]
+
+        # TODO!
         self.payoffPlot.plot(payoffs)
 
         # keep ranges consistent
-        self.licePopulationPlot.setXRange(0, len(payoffs), padding=0)
-        self.licePopulationPlot.vb.setLimits(xMin=0, xMax=len(payoffs))
+        for plot in self.licePopulationPlots:
+            plot.setXRange(0, len(payoffs), padding=0)
+            plot.vb.setLimits(xMin=0, xMax=len(payoffs))
         self.payoffPlot.setXRange(0, len(payoffs), padding=0)
         self.payoffPlot.vb.setLimits(xMin=0, xMax=len(payoffs))
-
 
     def _createActions(self):
         self.loadDumpAction = QAction("&Load Dump")
@@ -227,11 +275,7 @@ class Window(QMainWindow):
         pg.setConfigOption('background', background)
         pg.setConfigOption('foreground', foreground)
 
-        layout: QGridLayout = self.wd.layout()
-        layout.removeWidget(self.plotPane)
-        self._createPlots()
-        layout.addWidget(self.plotPane, 0, 0, 2, 1)
-        self._updatePlot()
+        self._remountPlot()
 
     def _updateRecentFilesActions(self):
         # Recent files
@@ -273,14 +317,13 @@ class Window(QMainWindow):
 
             self._createLoaderWorker(filename)
 
-
     def _openAboutMessage(self):
         QMessageBox.about(self, "About SLIM",
-            """
-            GUI for the Sea Lice sIMulator.
-            
-            For more details see https://github.com/resistance-modelling/slim
-            """)
+                          """
+                          GUI for the Sea Lice sIMulator.
+                          
+                          For more details see https://github.com/resistance-modelling/slim
+                          """)
 
     def helpContent(self):
         pass
@@ -300,6 +343,7 @@ class SimulatorLoadingWorker(QObject):
         states, times = Simulator.reload_all_dump(parent_path, sim_name)
         print("Loaded simulation")
         self.finished.emit(states, times)
+
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)


### PR DESCRIPTION
Just a quick PR to:

- implement data loading from a Pandas dataframe
- Add light/black mode switch
- Implement support for multiple farms. These are visualised in the same row and the y-axes are synchronised and there are limits in panning
- Some refactoring

The code is actually quite dirty: the plots update, clear and redraw logic is badly entangled with everything else. It would be good to turn that into a widget and add slots. But that will wait for another time.